### PR TITLE
Fix LinkedIn URL, fix Twitter username

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -17,14 +17,14 @@ export default function ContactPage() {
     },
     {
       name: "X (Twitter)",
-      value: "@bgub",
+      value: "@bgub_",
       href: "https://x.com/bgub_",
       description: "Follow me for quick updates and tech discussions",
     },
     {
       name: "LinkedIn",
       value: "Ben Gubler",
-      href: "https://linkedin.com/in/bengubler",
+      href: "https://www.linkedin.com/in/ben-gubler/",
       description: "Professional network and career-related discussions",
     },
     {


### PR DESCRIPTION
Hi Ben, thanks for your website here!

Quick PR to:

1. fix the LinkedIn URL (missing dash + LinkedIn URLs use a trailing slash)
2. Fix the displayed Twitter username