### PR TITLE
Improve page load speed

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -102,6 +102,8 @@ export default function RootLayout({
                             width={32}
                             height={32}
                             className="object-cover"
+                            priority
+                            sizes="32px"
                           />
                         </div>
                         <span className="text-lg font-semibold">

--- a/src/components/comments.tsx
+++ b/src/components/comments.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import Giscus from "@giscus/react";
+import dynamic from "next/dynamic";
 import { useTheme } from "next-themes";
+
+const Giscus = dynamic(() => import("@giscus/react"), { ssr: false });
 
 export function Comments() {
   const { resolvedTheme } = useTheme(); // "dark" | "light"

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -52,6 +52,8 @@ export function Sidebar() {
                 width={48}
                 height={48}
                 className="object-cover"
+                priority
+                sizes="48px"
               />
             </div>
             <div className="space-y-1 min-w-0 flex-1">


### PR DESCRIPTION
## Summary
- dynamically load Giscus comments widget to reduce script weight
- prioritize profile images for faster rendering

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_6883c4836220832ba2ea4114c275092f