### PR TITLE
fix(dropdown-menu): prevent layout shifting on theme toggle

### DIFF
--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -9,7 +9,7 @@ import { cn } from "@/lib/utils"
 function DropdownMenu({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
-  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" modal={false} {...props} />
 }
 
 function DropdownMenuPortal({


### PR DESCRIPTION
This PR fixes a UX issue where the page layout shifts when opening the theme toggle dropdown menu. 

### Changes
- Added `modal={false}` to `DropdownMenu.Root` to disable Radix UI's automatic body scroll lock.
- Ensures smoother UI experience without affecting dropdown functionality.